### PR TITLE
Fix/no more items crash

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,8 @@
 documentation:
   - .github/*
   - CHANGELOG.md
+  - LICENSE
+  - README.md
 
 test:
   - test/*

--- a/README.md
+++ b/README.md
@@ -1,49 +1,86 @@
-# BLoC Infinite List for Flutter
+I apologize for the oversight. Here’s the updated README with the badges at the start:
+
+```md
+## Infinite ListView for Flutter
 
 [![pub package](https://img.shields.io/pub/v/bloc_infinity_list.svg)](https://pub.dev/packages/bloc_infinity_list)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/frenkydema/bloc_infinity_list/flutter.yml)](https://github.com/frenkydema/bloc_infinity_list/actions/workflows/flutter.yml)
-[![Publish Status](https://img.shields.io/github/actions/workflow/status/frenkydema/bloc_infinity_list/publish.yml)](https://github.com/frenkydema/bloc_infinity_list/actions/workflows/publish.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-## Overview
+### Overview
 
-The **BLoC Infinite List** widget simplifies the creation of paginated lists in Flutter applications. It integrates seamlessly with the BLoC pattern, enabling you to automatically load more items as users scroll to the bottom of the list.
+The **Infinite ListView** widget is designed to simplify the creation of paginated lists in your
+Flutter application. This widget integrates seamlessly with the BLoC pattern and allows you to load
+more items as the user scrolls to the bottom of the list.
 
-## Features
+### Features
 
-- **Automatic Pagination**: Load more items automatically when the user scrolls to the end of the list.
-- **Refresh Control**: Built-in pull-to-refresh functionality to reload the entire list.
-- **Customizable UI**: Easily customize widgets for loading, error, and empty states.
-- **Debounced Scrolling**: Prevents rapid loading triggers with debounced scrolling for efficient data fetching.
-- **BLoC Integration**: Works with `flutter_bloc` for state and event management, ensuring clean and maintainable code.
-- **UI Customization**: Customize the list view with color, border radius, border color, border width, and box shadow.
-- **Custom Dividers**: Add custom dividers between items with the `dividerWidget`.
+- **Automatic Pagination**: Load more items automatically when the user reaches the bottom of the
+  list.
+- **Refresh Control**: Pull-to-refresh functionality to reload the entire list.
+- **Customizable UI**: Easily customize loading, error, and empty state widgets.
+- **Debounced Scrolling**: Prevents multiple loading triggers in rapid succession, ensuring
+  efficient data fetching.
+- **BLoC Integration**: Works with `flutter_bloc` to manage states and events, ensuring a clean and
+  maintainable codebase.
+- **UI Customization**: Customize the list container with color, border radius, border color, border
+  width, and box shadow.
+- **Custom Dividers**: Add custom dividers between list items using the `dividerWidget`.
 
-## Usage
+### Usage
 
-To use `BLoC Infinite List`, provide your BLoC instance and an item builder. The BLoC should manage loading the initial items and fetching more as needed.
+To use the Infinite ListView, you need to provide an instance of your BLoC and an item builder. The
+BLoC should handle loading initial items and fetching more items as needed.
+
+#### Creating a Custom BLoC
+
+Extend the `InfiniteListBloc` class to create your custom BLoC. Override the `fetchItems` method to
+define how items are fetched. Here’s an example of a custom BLoC implementation:
+
+```dart
+import 'package:bloc_infinity_list/bloc_infinity_list.dart';
+
+class MyCustomBloc extends InfiniteListBloc<ListItem> {
+  @override
+  Future<List<ListItem>> fetchItems(
+      {required int limit, required int offset}) async {
+    try {
+      await Future.delayed(Durations.long1);
+
+      if (offset >= 50) {
+        return [];
+      }
+
+      return List.generate(
+          limit, (index) => ListItem(name: 'Item ${offset + index + 1}'));
+    } on Exception {
+      rethrow;
+    }
+  }
+}
+```
+
+#### Example Usage
 
 ```dart
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'bloc_infinity_list_bloc/bloc_infinity_list_bloc.dart';
-import 'bloc_infinity_list_view.dart';
+import 'package:bloc_infinity_list/bloc_infinity_list.dart';
 
 class MyListPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final BLoCInfiniteListBloc<MyItem> bloc = BLoCInfiniteListBloc();
+    final MyCustomBloc bloc = MyCustomBloc();
 
     return Scaffold(
-      appBar: AppBar(title: Text('BLoC Infinite List Example')),
-      body: BLoCInfiniteListView<MyItem>(
+      appBar: AppBar(title: Text('Infinite ListView Example')),
+      body: InfiniteListView<ListItem>(
         bloc: bloc,
         itemBuilder: (context, item) => ListTile(title: Text(item.name)),
         dividerWidget: Divider(),
         loadingWidget: (context) => Center(child: CircularProgressIndicator()),
         errorWidget: (context, error) => Center(child: Text('Error: $error')),
         emptyWidget: (context) => Center(child: Text('No items available')),
-        noMoreItemWidget: (context) => Center(child: Text('No more items')),
         padding: EdgeInsets.all(16.0),
         color: Colors.white,
         borderRadius: BorderRadius.circular(10.0),
@@ -55,28 +92,3 @@ class MyListPage extends StatelessWidget {
   }
 }
 ```
-
-## Demo
-
-See how `BLoC Infinite List` works in action! Watch the demo video below or check out the screenshots:
-
-[![Demo Video](https://img.youtube.com/vi/your-video-id/0.jpg)](https://www.youtube.com/watch?v=your-video-id)
-
-## Installation
-
-Add the following to your `pubspec.yaml` file:
-
-```yaml
-dependencies:
-  bloc_infinity_list: ^0.0.6
-```
-
-Then run `flutter pub get` to install the package.
-
-## License
-
-`BLoC Infinite List` is licensed under the [MIT License](LICENSE).
-
-## Contact
-
-For questions or feedback, please reach out via [GitHub Issues](https://github.com/FrenkyDema/bloc_infinity_list/issues/new/choose).

--- a/README.md
+++ b/README.md
@@ -1,50 +1,49 @@
-## Infinite ListView for Flutter
+# BLoC Infinite List for Flutter
 
-### Overview
+[![pub package](https://img.shields.io/pub/v/bloc_infinity_list.svg)](https://pub.dev/packages/bloc_infinity_list)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/frenkydema/bloc_infinity_list/flutter.yml)](https://github.com/frenkydema/bloc_infinity_list/actions/workflows/flutter.yml)
+[![Publish Status](https://img.shields.io/github/actions/workflow/status/frenkydema/bloc_infinity_list/publish.yml)](https://github.com/frenkydema/bloc_infinity_list/actions/workflows/publish.yml)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-The **Infinite ListView** widget is designed to simplify the creation of paginated lists in your
-Flutter application. This widget integrates seamlessly with the BLoC pattern and allows you to load
-more items as the user scrolls to the bottom of the list.
+## Overview
 
-### Features
+The **BLoC Infinite List** widget simplifies the creation of paginated lists in Flutter applications. It integrates seamlessly with the BLoC pattern, enabling you to automatically load more items as users scroll to the bottom of the list.
 
-- **Automatic Pagination**: Load more items automatically when the user reaches the bottom of the
-  list.
-- **Refresh Control**: Pull-to-refresh functionality to reload the entire list.
-- **Customizable UI**: Easily customize loading, error, and empty state widgets.
-- **Debounced Scrolling**: Prevents multiple loading triggers in rapid succession, ensuring
-  efficient data fetching.
-- **BLoC Integration**: Works with `flutter_bloc` to manage states and events, ensuring a clean and
-  maintainable codebase.
-- **UI Customization**: Customize the list container with color, border radius, border color, border
-  width, and box shadow.
-- **Custom Dividers**: Add custom dividers between list items using the `dividerWidget`.
+## Features
 
-### Usage
+- **Automatic Pagination**: Load more items automatically when the user scrolls to the end of the list.
+- **Refresh Control**: Built-in pull-to-refresh functionality to reload the entire list.
+- **Customizable UI**: Easily customize widgets for loading, error, and empty states.
+- **Debounced Scrolling**: Prevents rapid loading triggers with debounced scrolling for efficient data fetching.
+- **BLoC Integration**: Works with `flutter_bloc` for state and event management, ensuring clean and maintainable code.
+- **UI Customization**: Customize the list view with color, border radius, border color, border width, and box shadow.
+- **Custom Dividers**: Add custom dividers between items with the `dividerWidget`.
 
-To use the Infinite ListView, you need to provide an instance of your BLoC and an item builder. The
-BLoC should handle loading initial items and fetching more items as needed.
+## Usage
+
+To use `BLoC Infinite List`, provide your BLoC instance and an item builder. The BLoC should manage loading the initial items and fetching more as needed.
 
 ```dart
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'infinite_list_bloc/infinite_list_bloc.dart';
-import 'infinite_list_view.dart';
+import 'bloc_infinity_list_bloc/bloc_infinity_list_bloc.dart';
+import 'bloc_infinity_list_view.dart';
 
 class MyListPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final InfiniteListBloc<MyItem> bloc = InfiniteListBloc();
+    final BLoCInfiniteListBloc<MyItem> bloc = BLoCInfiniteListBloc();
 
     return Scaffold(
-      appBar: AppBar(title: Text('Infinite ListView Example')),
-      body: InfiniteListView<MyItem>(
+      appBar: AppBar(title: Text('BLoC Infinite List Example')),
+      body: BLoCInfiniteListView<MyItem>(
         bloc: bloc,
         itemBuilder: (context, item) => ListTile(title: Text(item.name)),
-        dividerWidget: Divider(), // Custom divider between items
+        dividerWidget: Divider(),
         loadingWidget: (context) => Center(child: CircularProgressIndicator()),
         errorWidget: (context, error) => Center(child: Text('Error: $error')),
         emptyWidget: (context) => Center(child: Text('No items available')),
+        noMoreItemWidget: (context) => Center(child: Text('No more items')),
         padding: EdgeInsets.all(16.0),
         color: Colors.white,
         borderRadius: BorderRadius.circular(10.0),
@@ -55,3 +54,34 @@ class MyListPage extends StatelessWidget {
     );
   }
 }
+```
+
+## Demo
+
+See how `BLoC Infinite List` works in action! Watch the demo video below or check out the screenshots:
+
+[![Demo Video](https://img.youtube.com/vi/your-video-id/0.jpg)](https://www.youtube.com/watch?v=your-video-id)
+
+## Installation
+
+Add the following to your `pubspec.yaml` file:
+
+```yaml
+dependencies:
+  bloc_infinity_list: ^1.0.0
+```
+
+Then run `flutter pub get` to install the package.
+
+## Contributing
+
+Contributions are welcome! Please see our [contributing guidelines](CONTRIBUTING.md) for more details.
+
+## License
+
+`BLoC Infinite List` is licensed under the [MIT License](LICENSE).
+
+## Contact
+
+For questions or feedback, please reach out via [GitHub Issues](https://github.com/frenkydema/bloc_infinity_list/issues) or email us at [your.email@example.com](mailto:your.email@example.com).
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-I apologize for the oversight. Here’s the updated README with the badges at the start:
-
-```md
 ## Infinite ListView for Flutter
 
 [![pub package](https://img.shields.io/pub/v/bloc_infinity_list.svg)](https://pub.dev/packages/bloc_infinity_list)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The **Infinite ListView** widget is designed to simplify the creation of paginat
 Flutter application. This widget integrates seamlessly with the BLoC pattern and allows you to load
 more items as the user scrolls to the bottom of the list.
 
+[](https://github.com/user-attachments/assets/07dd8d58-70c5-4092-a0cf-ca9f7b3f0a14)
+
 ### Features
 
 - **Automatic Pagination**: Load more items automatically when the user reaches the bottom of the
@@ -89,3 +91,6 @@ class MyListPage extends StatelessWidget {
   }
 }
 ```
+
+
+

--- a/README.md
+++ b/README.md
@@ -68,14 +68,10 @@ Add the following to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  bloc_infinity_list: ^1.0.0
+  bloc_infinity_list: ^0.0.6
 ```
 
 Then run `flutter pub get` to install the package.
-
-## Contributing
-
-Contributions are welcome! Please see our [contributing guidelines](CONTRIBUTING.md) for more details.
 
 ## License
 
@@ -83,5 +79,5 @@ Contributions are welcome! Please see our [contributing guidelines](CONTRIBUTING
 
 ## Contact
 
-For questions or feedback, please reach out via [GitHub Issues](https://github.com/frenkydema/bloc_infinity_list/issues) or email us at [your.email@example.com](mailto:your.email@example.com).
+For questions or feedback, please reach out via [GitHub Issues](https://github.com/FrenkyDema/bloc_infinity_list/issues/new/choose).
 ```

--- a/README.md
+++ b/README.md
@@ -80,4 +80,3 @@ Then run `flutter pub get` to install the package.
 ## Contact
 
 For questions or feedback, please reach out via [GitHub Issues](https://github.com/FrenkyDema/bloc_infinity_list/issues/new/choose).
-```

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,7 +21,7 @@ class MyCustomBloc extends InfiniteListBloc<ListItem> {
     try {
       await Future.delayed(Durations.long1);
 
-      if (offset >= 100) {
+      if (offset >= 50) {
         return [];
       }
 
@@ -92,6 +92,9 @@ class _MyAppState extends State<MyApp> {
             ),
             emptyWidget: (context) => const Center(
               child: Text('No items available'),
+            ),
+            noMoreItemWidget: (context) => const Center(
+              child: Text('No more items available'),
             ),
           ),
         ),

--- a/lib/bloc_infinity_list.dart
+++ b/lib/bloc_infinity_list.dart
@@ -22,6 +22,9 @@ class InfiniteListView<T> extends StatefulWidget {
   /// A widget to display when there are no items in the list.
   final Widget Function(BuildContext context)? emptyWidget;
 
+  /// A widget to display when there are no more items in the list.
+  final Widget Function(BuildContext context)? noMoreItemWidget;
+
   /// A widget to display between the items in the list.
   final Widget? dividerWidget;
 
@@ -51,6 +54,7 @@ class InfiniteListView<T> extends StatefulWidget {
     this.loadingWidget,
     this.errorWidget,
     this.emptyWidget,
+    this.noMoreItemWidget,
     this.dividerWidget,
     this.padding,
     this.color,
@@ -191,10 +195,20 @@ class _InfiniteListViewState<T> extends State<InfiniteListView<T>> {
       BuildContext context, BaseInfiniteListState<T> state) {
     return switch (state) {
       LoadingState() => _loadingWidget(context),
-      NoMoreItemsState<T>() => _emptyWidget(context),
+      NoMoreItemsState<T>() => _noMoreItemWidget(context),
       _ => const SizedBox(),
     };
   }
+
+  /// Builds the widget for when there are no more items in the list.
+  Widget _noMoreItemWidget(BuildContext context) =>
+      widget.noMoreItemWidget?.call(context) ??
+      Center(
+        child: Text(
+          'No more items',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      );
 
   /// Builds the widget for an empty list.
   Widget _emptyWidget(BuildContext context) =>


### PR DESCRIPTION
## Describe your changes

This update introduces several improvements and fixes for the `bloc_infinity_list` package:

1. **Added `noMoreItemWidget`**: Introduced a new variable to handle the display of a widget when there are no more items to load. This allows for better differentiation between an empty list and a list that has reached the end.
2. **Updated README**: Enhanced the README file to provide clearer usage instructions and added badges for build status and publish status. Included a section for a demo video to showcase the widget in action.

## Issue ticket number and link

- Issue: [#123](https://github.com/frenkydema/bloc_infinity_list/issues/123) - Fix empty list handling and update README

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
